### PR TITLE
Correct logging deps issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -3,14 +3,11 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/core.async "0.3.443"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/core.async "0.7.559"]
                  [org.clojure/java.data "0.1.1"]
-                 [net.bytebuddy/byte-buddy "1.7.5"]
-                 [org.clojure/tools.logging "0.3.1"]
-                 [ch.qos.logback/logback-classic "1.2.3"]
-                 [nrepl "0.6.0"]
-                 [com.cemerick/pomegranate "1.0.0"]]
+                 [net.bytebuddy/byte-buddy "1.10.7"]
+                 [nrepl "0.6.0"]]
   :min-lein-version "2.0.0"
   :source-paths ["src/clojure"]
   :java-source-paths ["src/java"]

--- a/src/clojure/spring_repl/bootstrap.clj
+++ b/src/clojure/spring_repl/bootstrap.clj
@@ -1,10 +1,8 @@
 (ns spring-repl.bootstrap
-  (:require [clojure.core.async :refer [<! go go-loop]]
-            [spring-repl.pubsub :refer [sub-evt]]
-            [spring-repl.nrepl :refer [start-repl]]
-            [spring-repl.consumers :refer [info-listener error-listener main-listener]]))
-
-
+  (:require [spring-repl.nrepl :refer [start-repl]]
+            [spring-repl.consumers :refer [info-listener
+                                           error-listener
+                                           main-listener]]))
 
 (defn boot []
   (error-listener)

--- a/src/clojure/spring_repl/consumers.clj
+++ b/src/clojure/spring_repl/consumers.clj
@@ -5,30 +5,33 @@
             [clojure.tools.logging :as log]
             [clojure.pprint :refer [pprint]]))
 
-(defn info-listener []
+(defn info-listener
   "Listen for informational events"
+  []
   (let [ch (sub-evt :info-log :info-ch)]
     (go-loop
-      []
+     []
       (let [info (<! ch)]
         (log/info (-> info :evt :message)))
       (recur))))
 
-(defn error-listener []
+(defn error-listener
   "Listen for error events"
+  []
   (let [ch (sub-evt :error-log :err-ch)]
     (go-loop
-      []
+     []
       (let [info (<! ch)]
-        (log/error (-> info :evt :message)))
-      (recur))))
+        (log/error info)
+        (recur)))))
 
-(defn main-listener []
+(defn main-listener
   "Listen for main events, such as spring context creation"
+  []
   (let [ch (sub-evt :main-bus :main-ch)]
     (go-loop
-      []
+     []
       (let [info (<! ch)]
-        (log/infof "main bus event %s" (with-out-str (pprint info)))
+        (log/info "main bus event %s" (with-out-str (pprint info)))
         (stash-context (get-in info [:evt :app-context]))
-      (recur)))))
+        (recur)))))


### PR DESCRIPTION
slf4j deps were being included in the agent jar which could
cause really odd runtime failures when running your application
with this agent. The agent included logging deps in the jar,
which could cause issues with your environment. I did not notice this
until running with spring-boot under gradle and a large legacy maven application.
In the interest of preventing future headaches, there is now no log4j or slf4j/logback
dependency included by this agent.

The only non-clojure dependency in the agent is now bytebuddy.
Bytebuddy is a nice library, but I'd like to get rid of it as well.
See https://github.com/tstout/cafebabe if you would like to help.